### PR TITLE
DRACO-2883 Include generated (but invalid) XML in XSD exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* [DRACO-2883](http://tickets.turner.com/browse/DRACO-2883): Include generated
+  (but invalid) XML in XSD exceptions. The constructor of
+  [XsdValidationException](src/Exception/XsdValidationException.php) has been
+  changed to add the original \DOMDocument, and a get method added to retrieve
+  it later.
+
 ### Changed
 
 ### Fixed

--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -65,7 +65,7 @@ class Encoder extends XmlEncoder
         libxml_disable_entity_loader($disableEntities);
 
         if (!$valid) {
-            throw new XsdValidationException($error);
+            throw new XsdValidationException($error, $dom);
         }
 
         return $dom->saveXML();

--- a/src/Exception/XsdValidationException.php
+++ b/src/Exception/XsdValidationException.php
@@ -23,8 +23,8 @@ class XsdValidationException extends UnexpectedValueException
     /**
      * Construct a new XsdValidationException.
      *
-     * @param \LibXMLError $error  The error that triggered the exception.
-     * @param \DOMDocument $dom               The invalid XML document.
+     * @param \LibXMLError    $error    The error that triggered the exception.
+     * @param \DOMDocument    $dom      The invalid XML document.
      * @param \Exception|null $previous (optional) A previous exception, if it exists.
      */
     public function __construct(\LibXMLError $error, \DOMDocument $dom, \Exception $previous = null)

--- a/src/Exception/XsdValidationException.php
+++ b/src/Exception/XsdValidationException.php
@@ -13,9 +13,25 @@ class XsdValidationException extends UnexpectedValueException
      */
     protected $xmlError;
 
-    public function __construct(\LibXMLError $error, \Exception $previous = null)
+    /**
+     * The invalid XML document.
+     *
+     * @var \DOMDocument
+     */
+    protected $dom;
+
+    /**
+     * Construct a new XsdValidationException.
+     *
+     * @param \LibXMLError $error  The error that triggered the exception.
+     * @param \DOMDocument $dom               The invalid XML document.
+     * @param \Exception|null $previous (optional) A previous exception, if it exists.
+     */
+    public function __construct(\LibXMLError $error, \DOMDocument $dom, \Exception $previous = null)
     {
         $this->xmlError = $error;
+        $this->dom = $dom;
+
         switch ($error->level) {
             case LIBXML_ERR_WARNING:
                 $level = 'warning';
@@ -42,5 +58,15 @@ class XsdValidationException extends UnexpectedValueException
     public function getXmlError()
     {
         return $this->xmlError;
+    }
+
+    /**
+     * The invalid XML document.
+     *
+     * @return \DOMDocument
+     */
+    public function getInvalidXmlDocument()
+    {
+        return $this->dom;
     }
 }

--- a/tests/src/Exception/XsdValidationExceptionTest.php
+++ b/tests/src/Exception/XsdValidationExceptionTest.php
@@ -19,7 +19,7 @@ class XsdValidationExceptionTest extends TestCase
     public function testGetXmlError()
     {
         $error = $this->getLibXmlError();
-        $e = new XsdValidationException($error);
+        $e = new XsdValidationException($error, new \DOMDocument());
         $this->assertEquals($error, $e->getXmlError());
     }
 
@@ -35,7 +35,7 @@ class XsdValidationExceptionTest extends TestCase
     {
         $error = $this->getLibXmlError();
         $error->level = $level;
-        $e = new XsdValidationException($error);
+        $e = new XsdValidationException($error, new \DOMDocument());
         $this->assertEquals("XSD validation $string code 123 in /tmp/file.xml line 789 column 456: This is a test", $e->getMessage());
     }
 
@@ -47,7 +47,7 @@ class XsdValidationExceptionTest extends TestCase
     public function testGetCode()
     {
         $error = $this->getLibXmlError();
-        $e = new XsdValidationException($error);
+        $e = new XsdValidationException($error, new \DOMDocument());
         $this->assertEquals($error->code, $e->getCode());
     }
 
@@ -60,8 +60,21 @@ class XsdValidationExceptionTest extends TestCase
     {
         $error = $this->getLibXmlError();
         $previous = new \Exception();
-        $e = new XsdValidationException($error, $previous);
+        $e = new XsdValidationException($error, new \DOMDocument(), $previous);
         $this->assertEquals($previous, $e->getPrevious());
+    }
+
+    /**
+     * Test that we can retrieve the invalid XML document.
+     *
+     * @covers ::getInvalidXmlDocument
+     */
+    public function testGetInvalidXmlDocument()
+    {
+        $error = $this->getLibXmlError();
+        $dom = new \DOMDocument();
+        $e = new XsdValidationException($error, $dom);
+        $this->assertEquals($dom, $e->getInvalidXmlDocument());
     }
 
     /**


### PR DESCRIPTION
I decided to attach the \DOMDocument instead of the XML string so callers don't have to reparse the XML if they don't want to.